### PR TITLE
Fix typo

### DIFF
--- a/workshop/00_quickstart/00_Overview.ipynb
+++ b/workshop/00_quickstart/00_Overview.ipynb
@@ -69,7 +69,7 @@
     "このワークショップでは以下の内容について学びます。\n",
     "\n",
     "* Amazon AthenaとParquetデータフォーマットを使用したS3へのデータの取り込み\n",
-    "* SageMakerノートブック上でのpandaやmatplotlibによるデータの可視化\n",
+    "* SageMakerノートブック上でのpandasやmatplotlibによるデータの可視化\n",
     "* SageMaker Clarifyを使用したデータバイアス分析の実行\n",
     "* Scikit-LearnおよびSageMaker Processing Jobを使用した生データセットに対する特徴量エンジニアリングの実行\n",
     "* SageMaker Feature Storeを使用した特徴量の保存と共有\n",


### PR DESCRIPTION
原著版リポジトリを参考に`pandas`が`panda`になっていたので修正しました。

[Original Code](https://github.com/data-science-on-aws/oreilly_book/blob/book/00_quickstart/00_Overview.ipynb)